### PR TITLE
Ensure we use utf-8 encoding in EmailSender

### DIFF
--- a/src/main/scala/fm/common/EmailSender.scala
+++ b/src/main/scala/fm/common/EmailSender.scala
@@ -57,8 +57,8 @@ final case class EmailSender (user: String, pass: String, host: String) {
     }
 
     message.setSentDate(new java.util.Date)
-    message.setSubject(subject)
-    message.setText(body)
+    message.setSubject(subject, "utf-8")
+    message.setText(body, "utf-8")
     
     // Not AutoCloseable
     val transport: Transport = session.getTransport("smtp")


### PR DESCRIPTION
The linux environment behaves differently than our local machines :/ - need to override/explicitly specify the utf-8 encoding.