### PR TITLE
RichString helper to convert language tag to Locale using a pattern we use heavily in ta-catalog

### DIFF
--- a/jvm/src/main/scala/fm/common/Implicits.scala
+++ b/jvm/src/main/scala/fm/common/Implicits.scala
@@ -44,6 +44,7 @@ trait Implicits extends ImplicitsBase {
   implicit def toRichAwait[V](await: Await.type): RichAwait = new RichAwait(await)
   
   implicit def toRichFile(f: File): RichFile = new RichFile(f)
+  implicit def toRichJVMString(s: String): RichJVMString = new RichJVMString(s)
   implicit def toRichPath(p: Path): RichPath = new RichPath(p)
   implicit def toRichInputStream(is: InputStream): RichInputStream = new RichInputStream(is)
   

--- a/jvm/src/main/scala/fm/common/rich/RichJVMString.scala
+++ b/jvm/src/main/scala/fm/common/rich/RichJVMString.scala
@@ -1,0 +1,10 @@
+package fm.common.rich
+
+// not scala-js compatible
+import java.util.Locale
+
+final class RichJVMString(val s: String) extends AnyVal {
+  // Parse a language tag to a locale - Using Locale.Builder() instead of Locale.forLanguageTag catches malformed strings
+  def toLocaleOption: Option[Locale] = scala.util.Try{ new Locale.Builder().setLanguageTag(s).build() }.toOption
+  def toLocale: Locale = toLocaleOption.getOrElse(throw new Exception(s"Invalid locale language tag: $s"))
+}

--- a/jvm/src/test/scala/fm/common/rich/TestRichJVMString.scala
+++ b/jvm/src/test/scala/fm/common/rich/TestRichJVMString.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2014 Frugal Mechanic (http://frugalmechanic.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fm.common.rich
+import java.util.Locale
+import org.scalatest.{FunSuite, Matchers}
+
+final class TestRichJVMString extends FunSuite with Matchers {
+  import fm.common.Implicits._
+
+  test("toLocaleOption") {
+    "en-US".toLocaleOption should equal (Some(Locale.US))
+    "es-US".toLocaleOption should equal (Some(Locale.forLanguageTag("es-US")))
+    "foo bar".toLocaleOption should equal (None)
+  }
+}


### PR DESCRIPTION
@tpunder since locale isn't js-friendly I added a separate "RichJVMString.scala" file into the jvm directory does that name convention work?