### PR TITLE
Update the logic for the RichLocale - pretty sure these aren't being …

### DIFF
--- a/jvm/src/main/scala/fm/common/rich/RichLocale.scala
+++ b/jvm/src/main/scala/fm/common/rich/RichLocale.scala
@@ -50,10 +50,11 @@ final class RichLocale(val self: Locale) extends AnyVal {
   
   def languageTag: String = self.toLanguageTag()
   
-  def isValidLanguage: Boolean = Try{ self.getISO3Language }.isSuccess
-  def isValidCountry: Boolean = Try{ self.getISO3Country }.isSuccess
+  def isValidLanguage: Boolean = Try{ self.getISO3Language }.filter(_.nonEmpty).toOption.isDefined
+  def isValidCountry: Boolean = Try{ self.getISO3Country }.filter(_.nonEmpty).toOption.isDefined
+  def hasCountry: Boolean = isValidCountry
   
-  def isValid: Boolean = isValidLanguage && isValidCountry
+  def isValid: Boolean = isValidLanguage // && isValidCountry
   
   def displayName(implicit locale: Locale): String = self.getDisplayName(locale)
   def displayCountry(implicit locale: Locale): String = self.getDisplayCountry(locale)

--- a/jvm/src/test/scala/fm/common/rich/TestRichLocale.scala
+++ b/jvm/src/test/scala/fm/common/rich/TestRichLocale.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Frugal Mechanic (http://frugalmechanic.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fm.common.rich
+import java.util.Locale
+import org.scalatest.{FunSuite, Matchers}
+
+final class TestRichLocale extends FunSuite with Matchers {
+  import fm.common.Implicits._
+
+  test("isValidLanguage") {
+    Locale.US.isValidLanguage                      should equal (true)
+    Locale.forLanguageTag("en").isValidLanguage    should equal (true)
+    Locale.forLanguageTag("en-US").isValidLanguage should equal (true)
+    Locale.forLanguageTag("zz-US").isValidLanguage should equal (false)
+    Locale.forLanguageTag("zz").isValidLanguage    should equal (false)
+  }
+
+  test("isValidCountry") {
+    Locale.US.isValidCountry                      should equal (true)
+    Locale.forLanguageTag("en").isValidCountry    should equal (false)
+    Locale.forLanguageTag("en-US").isValidCountry should equal (true)
+    Locale.forLanguageTag("zz-US").isValidCountry should equal (true)
+    Locale.forLanguageTag("zz").isValidCountry    should equal (false)
+    Locale.forLanguageTag("en-zz").isValidCountry should equal (false)
+  }
+}


### PR DESCRIPTION
…used anywhere because they would have caused problems...


The places we reference this aren't really interested in the country, just the language:

```
fm-common/jvm/src/main/scala/fm/common/rich/RichJVMString.scala:8:  def toLocaleOption: Option[Locale] = scala.util.Try{ new Locale.Builder().setLanguageTag(s).build() }.toOption.filter{ _.isValid }
fm-common-web/src/main/scala/fm/i18n/I18NStrings.scala:59:      if (!locale.isValid) {
fm-tecdoc/src/main/scala/fm/tecdoc/tables/TecDocTableExtensions.scala:168:      require(locale.isValid, s"Unknown Lanauge: $lang - ${lang.description(DE)}")
ta-catalog/src/main/scala/ta/catalog/website/WebConfigCtx.scala:82:    request.params.getFirstNonBlank("lang").flatMap{ lang: String => lang.toLocaleOption }.filter{ _.isValid }
tmp/ta-catalog/src/main/scala/ta/catalog/website/pages/PageHelpers.scala:414:    request.params.getFirstNonBlank("lang").flatMap{ lang: String => lang.toLocaleOption }.filter{ _.isValid }
```

In theory this could break something since...

    scala> Locale.forLanguageTag("").isValidLanguage
    res15: Boolean = true

Would basically always return true...but since most of these are doing filters, I think it will be fine