### PR TITLE
Add UndefNullOr and NullOr type helpers for use in scala.js code.

### DIFF
--- a/js/src/main/scala/fm/common/jshelpers/NullOr.scala
+++ b/js/src/main/scala/fm/common/jshelpers/NullOr.scala
@@ -1,0 +1,13 @@
+package fm.common.jshelpers
+
+import scala.scalajs.js
+
+// Similar to js.UndefOr, except handles converting nulls into Options
+@js.native
+sealed trait NullOr[+A] extends js.Any
+
+object NullOr {
+  implicit class NullOrOps[+A](val self: NullOr[A]) extends AnyVal {
+    def toOption: Option[A] = Option(self).asInstanceOf[Option[A]]
+  }
+}

--- a/js/src/main/scala/fm/common/jshelpers/UndefNullOr.scala
+++ b/js/src/main/scala/fm/common/jshelpers/UndefNullOr.scala
@@ -1,0 +1,19 @@
+package fm.common.jshelpers
+
+import scala.scalajs.js
+
+// Similar to js.UndefOr, except it also handles null's
+@js.native
+sealed trait UndefNullOr[+A] extends js.Any
+
+object UndefNullOr {
+  implicit class UndefNullOrOps[+A](val self: UndefNullOr[A]) extends AnyVal {
+    def toOption: Option[A] = {
+      self match {
+        case v if js.isUndefined(v) => None
+        case v if v.isNull          => None
+        case v: A                   => Option(v).asInstanceOf[Option[A]]
+      }
+    }
+  }
+}


### PR DESCRIPTION
used `jshelpers` to prevent interfering with the `js` package namespace for `scalajs`