### PR TITLE
Added containsNormalized, indexedOfNormalized, equalsNormalized, containsIgnoreCase and indexOfIgnoreCase to RichCharSequence

### DIFF
--- a/bench/src/main/scala/fm/common/bench/BenchRichCharSequence.scala
+++ b/bench/src/main/scala/fm/common/bench/BenchRichCharSequence.scala
@@ -1,0 +1,58 @@
+package fm.common.bench
+
+import fm.common.Implicits._
+import org.openjdk.jmh.annotations.Benchmark
+
+class BenchRichCharSequence {
+
+  //
+  // 1
+  //
+
+  private def exampleString1: String = " a B c D e F g H i J k L m N o P"
+  private def exampleString1Target: String = "   defghij    "
+
+  @Benchmark
+  def containsNormalizedManual1: Boolean = {
+    exampleString1.lowerAlphaNumeric.contains(exampleString1Target.lowerAlphaNumeric)
+  }
+
+  @Benchmark
+  def containsNormalizedOptimized1: Boolean = {
+    exampleString1.containsNormalized(exampleString1Target)
+  }
+
+  //
+  // 2
+  //
+
+  private def exampleString2: String = "soMeStRiNgExAcTfOoBaR"
+  private def exampleString2Target: String = "eXaCt"
+
+  @Benchmark
+  def containsNormalizedManual2: Boolean = {
+    exampleString2.lowerAlphaNumeric.contains(exampleString2Target.lowerAlphaNumeric)
+  }
+
+  @Benchmark
+  def containsNormalizedOptimized2: Boolean = {
+    exampleString2.containsNormalized(exampleString2Target)
+  }
+
+  //
+  // 3
+  //
+
+  private def exampleString3: String = "ExAcT"
+  private def exampleString3Target: String = "eXaCt"
+
+  @Benchmark
+  def containsNormalizedManual3: Boolean = {
+    exampleString3.lowerAlphaNumeric.contains(exampleString3Target.lowerAlphaNumeric)
+  }
+
+  @Benchmark
+  def containsNormalizedOptimized3: Boolean = {
+    exampleString3.containsNormalized(exampleString3Target)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ scalaVersion in ThisBuild := "2.12.6"
 crossScalaVersions in ThisBuild := Seq("2.11.11", "2.12.6")
 
 lazy val `fm-common` = project.in(file(".")).
-  aggregate(fmCommonJS, fmCommonJVM).
+  aggregate(fmCommonJS, fmCommonJVM, `fm-common-bench`).
   settings(FMPublic ++ Seq(
     publish := {},
     publishLocal := {},
@@ -73,7 +73,13 @@ lazy val `fm-common-` = crossProject.in(file(".")).
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.6",
     libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.4"
   )
+  
+lazy val `fm-common-bench` = project.in(file("bench")).settings(
+  publish := {},
+  publishLocal := {},
+  publishArtifact := false,
+  publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo"))), // http://stackoverflow.com/a/18522706  
+).enablePlugins(JmhPlugin).dependsOn(fmCommonJVM, `fm-common-macros`)
 
 lazy val fmCommonJVM = `fm-common-`.jvm.dependsOn(`fm-common-macros` % "compile-internal, test-internal")
 lazy val fmCommonJS = `fm-common-`.js.dependsOn(`fm-common-macros` % "compile-internal, test-internal")
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
 addSbtPlugin("com.frugalmechanic" % "fm-sbt-common" % "0.20.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
+

--- a/shared/src/main/scala/fm/common/rich/RichCharSequence.scala
+++ b/shared/src/main/scala/fm/common/rich/RichCharSequence.scala
@@ -112,12 +112,20 @@ final class RichCharSequence(val s: CharSequence) extends AnyVal {
     containsWithTransform(target, Character.isLetterOrDigit(_), (c: Char) => Character.toLowerCase(ASCIIUtil.toASCIIChar(c)))
   }
 
+  def containsIgnoreCase(target: CharSequence): Boolean = {
+    containsWithTransform(target, (_: Char) => true, (c: Char) => Character.toLowerCase(c))
+  }
+
   @inline def containsWithTransform(target: CharSequence, filter: Char => Boolean, map: Char => Char): Boolean = {
     indexOfWithTransform(target, filter, map) > -1
   }
 
   def indexOfNormalized(target: CharSequence): Int = {
     indexOfWithTransform(target, Character.isLetterOrDigit(_), (c: Char) => Character.toLowerCase(ASCIIUtil.toASCIIChar(c)))
+  }
+
+  def indexOfIgnoreCase(target: CharSequence): Int = {
+    indexOfWithTransform(target, (_: Char) => true, (c: Char) => Character.toLowerCase(c))
   }
 
   @inline def indexOfWithTransform(target: CharSequence, filter: Char => Boolean, map: Char => Char): Int = {
@@ -187,7 +195,7 @@ final class RichCharSequence(val s: CharSequence) extends AnyVal {
     equalsWithTransform(target, Character.isLetterOrDigit(_), (c: Char) => Character.toLowerCase(ASCIIUtil.toASCIIChar(c)))
   }
 
-  def equalsWithTransform(target: CharSequence, filter: Char => Boolean, map: Char => Char): Boolean = {
+  @inline def equalsWithTransform(target: CharSequence, filter: Char => Boolean, map: Char => Char): Boolean = {
     if (null == s || null == target) return false
 
     var sourceIdx: Int = 0

--- a/shared/src/test/scala/fm/common/rich/TestRichCharSequence.scala
+++ b/shared/src/test/scala/fm/common/rich/TestRichCharSequence.scala
@@ -97,4 +97,30 @@ final class TestRichCharSequence extends FunSuite with Matchers {
     "aaaaaaaa".indexesOf("b", withOverlaps = false) should equal (Nil)
   }
 
+  test("equalsNormalized") {
+    (null: String).equalsNormalized(null) should equal (false)
+    (null: String).equalsNormalized("") should equal (false)
+    "".equalsNormalized(null) should equal (false)
+
+    "".equalsNormalized("") should equal (true)
+    "foo".equalsNormalized("foo") should equal (true)
+    "foo".equalsNormalized(" fOo ") should equal (true)
+    "  F o O B a R ".equalsNormalized(" fOo bAr ") should equal (true)
+  }
+
+  test("indexOfNormalized / containsNormalized") {
+    checkIndexOfNormalized(null, null, -1)
+    checkIndexOfNormalized(null, "", -1)
+    checkIndexOfNormalized("", null, -1)
+
+    checkIndexOfNormalized("", "", 0)
+    checkIndexOfNormalized("foo", "", 0)
+    checkIndexOfNormalized("foo", "foo", 0)
+    checkIndexOfNormalized("  F o O B a R ", " fOo bAr ", 2)
+  }
+
+  private def checkIndexOfNormalized(s: CharSequence, target: CharSequence, idx: Int): Unit = {
+    s.indexOfNormalized(target) should equal (idx)
+    s.containsNormalized(target) should equal (idx > -1)
+  }
 }

--- a/shared/src/test/scala/fm/common/rich/TestRichCharSequence.scala
+++ b/shared/src/test/scala/fm/common/rich/TestRichCharSequence.scala
@@ -108,6 +108,20 @@ final class TestRichCharSequence extends FunSuite with Matchers {
     "  F o O B a R ".equalsNormalized(" fOo bAr ") should equal (true)
   }
 
+  test("containsIgnoreCase") {
+    (null: String).containsIgnoreCase(null) should equal (false)
+    (null: String).containsIgnoreCase("") should equal (false)
+    "".containsIgnoreCase(null) should equal (false)
+
+    "".containsIgnoreCase("") should equal (true)
+    "foo".containsIgnoreCase("foo") should equal (true)
+    "FOO".containsIgnoreCase("foo") should equal (true)
+    "FOO".containsIgnoreCase("FOO") should equal (true)
+    "FoO".containsIgnoreCase("fOo") should equal (true)
+    "foo".containsIgnoreCase(" fOo ") should equal (false)
+    "  F o O B a R ".containsIgnoreCase(" fOo bAr ") should equal (false)
+  }
+
   test("indexOfNormalized / containsNormalized") {
     checkIndexOfNormalized(null, null, -1)
     checkIndexOfNormalized(null, "", -1)
@@ -119,8 +133,34 @@ final class TestRichCharSequence extends FunSuite with Matchers {
     checkIndexOfNormalized("  F o O B a R ", " fOo bAr ", 2)
   }
 
+  test("indexOfIgnoreCase / containsIgnoreCase") {
+    checkIndexOfIgnoreCase(null, null, -1)
+    checkIndexOfIgnoreCase(null, "", -1)
+    checkIndexOfIgnoreCase("", null, -1)
+
+    checkIndexOfIgnoreCase("", "", 0)
+    checkIndexOfIgnoreCase("foo", "", 0)
+    checkIndexOfIgnoreCase("foo", "foo", 0)
+    checkIndexOfIgnoreCase("  F o O B a R ", " fOo bAr ", -1)
+
+    checkIndexOfIgnoreCase("foo", "FOO", 0)
+    checkIndexOfIgnoreCase("FOO", "foo", 0)
+    checkIndexOfIgnoreCase("fOo", "FoO", 0)
+
+    checkIndexOfIgnoreCase("  foo  ", "FOO", 2)
+    checkIndexOfIgnoreCase("asdasd  FOO  12313!@#!#", "foo", 8)
+    checkIndexOfIgnoreCase("!@#!@# fOo!@#!@#!#", "FoO", 7)
+
+    checkIndexOfIgnoreCase("foo", "asdasdfooadasd", -1)
+  }
+
   private def checkIndexOfNormalized(s: CharSequence, target: CharSequence, idx: Int): Unit = {
     s.indexOfNormalized(target) should equal (idx)
     s.containsNormalized(target) should equal (idx > -1)
+  }
+
+  private def checkIndexOfIgnoreCase(s: CharSequence, target: CharSequence, idx: Int): Unit = {
+    s.indexOfIgnoreCase(target) should equal (idx)
+    s.containsIgnoreCase(target) should equal (idx > -1)
   }
 }


### PR DESCRIPTION
Still trying to figure out if this is a good idea or not but we have several places in our code where we do "normalized" comparisons (usually looping over some collection):

```scala
someString.lowerAlphaNumeric.contains(someTarget.lowerAlphaNumeric)
```

This requires new String/char[] allocations.  This pull request adds the ability to do something like:

```scala
someString.containsNormalized(someTarget)
```
which should have no allocations (assuming the Scala optimize properly inlines methods).

I have not done extensive testing to figure out if there is actually a performance benefit to this approach or not.  It is possible that the JVM is faster to do the bulk normalization on the string along with the String/char[] allocation than this method which looks at the chars one by one.