### PR TITLE
Fix insertAfter to appendChild in the parentNode if there is no nextSibling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,8 @@ lazy val `fm-common-` = crossProject.in(file(".")).
     // Add JS-specific settings here
     libraryDependencies += "be.doeraene" %%% "scalajs-jquery" % "0.9.4",
     libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-    libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.5"
+    libraryDependencies += "org.scala-js" %%% "scalajs-java-time" % "0.2.5",
+    jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
   )
   
 lazy val `fm-common-bench` = project.in(file("bench")).settings(

--- a/js/src/main/scala/fm/common/rich/RichNode.scala
+++ b/js/src/main/scala/fm/common/rich/RichNode.scala
@@ -31,7 +31,9 @@ final class RichNode[T <: Node](val self: T) extends AnyVal {
   
   /** Find the closest ancestor of the current element (or the current element itself) that matches a class. */
   def closest[A <: Node : ClassTag]: A = closestImpl(self)
-  
+
+  def hasNextSibling: Boolean = self.nextSibling.isNotNull
+
   @tailrec
   private def closestImpl[A <: Node : ClassTag](node: Node): A = {
     if (classTag[A].runtimeClass.isInstance(node)) node.asInstanceOf[A]
@@ -43,11 +45,17 @@ final class RichNode[T <: Node](val self: T) extends AnyVal {
   def prependChild(node: Node): Node = self.insertBefore(node, self.firstChild)
   
   /** Like insertBefore but insert after the passed in node */
-  def insertAfter(node: Node, refChild: Node): Node = refChild.parentNode.insertBefore(node, refChild.nextSibling)
+  def insertAfter(node: Node, refChild: Node): Node = {
+    if (refChild.hasNextSibling) self.insertBefore(node, refChild.nextSibling)
+    else self.appendChild(node)
+  }
   
   /** Insert the passed in node before the current node */
   def insertBefore(node: Node): Node = self.parentNode.insertBefore(node, self)
   
   /** Insert the passed in node after the current node */
-  def insertAfter(node: Node): Node = self.parentNode.insertBefore(node, self.nextSibling)
+  def insertAfter(node: Node): Node = {
+    if (self.hasNextSibling) self.parentNode.insertBefore(node, self.nextSibling)
+    else self.parentNode.appendChild(node)
+  }
 }

--- a/js/src/test/scala/fm/common/rich/TestRichNode.scala
+++ b/js/src/test/scala/fm/common/rich/TestRichNode.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Frugal Mechanic (http://frugalmechanic.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fm.common.rich
+
+import org.scalajs.dom.document
+import org.scalajs.dom.raw.Element
+import org.scalatest.{FunSuite, Matchers}
+import scala.scalajs.js.JavaScriptException
+
+final class TestRichNode extends FunSuite with Matchers {
+  import fm.common.Implicits.toRichNode
+
+  private def newListItem(): Element = {
+    val newNode = document.createElement("li")
+    newNode.innerHTML = "new node"
+    newNode.id = "new"
+
+    newNode
+  }
+
+  private def setupInsertAfterUL(): Unit = {
+    document.body.innerHTML =
+      s"""
+         |<ul id="outer-ul">
+         |  <li id="one">one</li>
+         |  <li id="two">
+         |    <ul id="inner-ul">
+         |      <li id="inner-one">inner-one</li>
+         |      <li id="inner-two">inner-two</li>
+         |    </ul>
+         |  </li>
+         |  <li id="three">three</li>
+         |</ul>
+       """.stripMargin.linesIterator.map{ _.trim }.mkString("") // remove whitespace/newlines
+  }
+
+
+
+  private def testFullInsertAfterImpl(parentId: String = "outer-ul", targetId: String, useParent: Boolean = true, expectedCount: Int = 4): Unit = {
+    setupInsertAfterUL()
+
+    val ul: Element = document.getElementById(parentId)
+    ul.childElementCount should equal(3)
+
+    testInsertAfterImpl(parentId, targetId, useParent, expectedCount)
+  }
+
+  private def testInsertAfterImpl(parentId: String = "outer-ul", targetId: String, useParent: Boolean = true, expectedCount: Int): Unit = {
+    withClue(s"testInsertAfterImpl($parentId, $targetId, $useParent, $expectedCount)"){
+      val ul: Element = document.getElementById(parentId)
+      val targetChild: Element = document.getElementById(targetId)
+
+      // Insert after
+      val newNode: Element = newListItem()
+      if (useParent) ul.insertAfter(newNode, targetChild)
+      else targetChild.insertAfter(newNode)
+
+      // Verify Insert
+      ul.childElementCount should equal(expectedCount)
+      targetChild.nextElementSibling should equal(newNode)
+    }
+  }
+
+  test("hasNextSibling") {
+    def testHasNextSiblingImpl(id: String, expected: Boolean): Unit = {
+      withClue(s"hasNextSibling: $id") {
+        document.getElementById(id).hasNextSibling should equal(expected)
+      }
+    }
+
+    setupInsertAfterUL()
+
+    testHasNextSiblingImpl("outer-ul", false)
+    testHasNextSiblingImpl("one", true)
+    testHasNextSiblingImpl("two", true)
+    testHasNextSiblingImpl("three", false)
+    testHasNextSiblingImpl("inner-ul", false)
+    testHasNextSiblingImpl("inner-one", true)
+    testHasNextSiblingImpl("inner-two", false)
+  }
+
+  test("insertAfter(node: Node, refChild: Node)") {
+    testFullInsertAfterImpl(targetId = "one")
+    testFullInsertAfterImpl(targetId = "two")
+    testFullInsertAfterImpl(targetId = "three")
+
+    // Add another new node to ensure it is targetable
+    testInsertAfterImpl(targetId = "new", expectedCount = 5)
+
+    assertThrows[JavaScriptException] {
+      testInsertAfterImpl(targetId = "no-target", expectedCount = 0)
+    }
+  }
+
+  test("insertAfter(node: Node)") {
+    testFullInsertAfterImpl(targetId = "one", useParent = false)
+    testFullInsertAfterImpl(targetId = "two", useParent = false)
+    testFullInsertAfterImpl(targetId = "three", useParent = false)
+
+    // Add another new node again
+    testInsertAfterImpl(targetId = "new", useParent = false, expectedCount = 5)
+
+    assertThrows[JavaScriptException] {
+      testInsertAfterImpl(targetId = "no-target", useParent = false, expectedCount = 0)
+    }
+  }
+
+  test("insertAfter - inner append") {
+    setupInsertAfterUL()
+
+    val ul = document.getElementById("inner-ul")
+    ul.childElementCount should equal(2)
+
+    testInsertAfterImpl("inner-ul", targetId = "inner-one", expectedCount = 3)
+    testInsertAfterImpl("inner-ul", targetId = "inner-two", expectedCount = 4)
+  }
+
+  test("insertAfter - inner append - from outer - throws exception") {
+    setupInsertAfterUL()
+
+    val ul = document.getElementById("inner-ul")
+    ul.childElementCount should equal(2)
+
+    assertThrows[JavaScriptException] {
+      testInsertAfterImpl("outer-ul", targetId = "inner-one", useParent = true, expectedCount = 3)
+    }
+  }
+}


### PR DESCRIPTION
I feel like the logic was wrong in `def insertAfter(node: Node, refChild: Node): Node = refChild.parentNode.insertBefore(node, refChild.nextSibling)` to use the `refChild.parentNode.insertBefore`.  I think to match the built-in browser default implementation it should still be triggering off the `self.insertBefore` or the `self.parentNode.appendChild(node)` as a fallback.