### PR TITLE
Add optional Set[Char] whitelist to lowerAlphanumeric* helpers

### DIFF
--- a/shared/src/main/scala/fm/common/ASCIIUtil.scala
+++ b/shared/src/main/scala/fm/common/ASCIIUtil.scala
@@ -59,14 +59,22 @@ object ASCIIUtil {
     // calling stripAccentCharImpl()
     if (c < '\u0080') c else stripAccentCharImpl(c)
   }
-  
+
   /**
    * Converts Accented Characters to the Non-Accented Equivalent String (or null if already ASCII or no conversion exists).
    */
   def toASCIICharsOrNull(c: Char): String = {
-    if (c < '\u0080') null else stripAccentStringImplOrNull(c)
+    toASCIICharsOrNull(c, Set.empty)
   }
-  
+
+  /**
+   * Like toASCIICharsOrNull except any characters in the whitelist will also return null
+   */
+  def toASCIICharsOrNull(c: Char, whitelist: Set[Char]): String = {
+    if (c < '\u0080' || whitelist.contains(c)) null
+    else stripAccentStringImplOrNull(c)
+  }
+
   /**
    * Converts Accented Characters to the Non-Accented Equivalent String.
    *

--- a/shared/src/test/scala/fm/common/TestASCIIUtil.scala
+++ b/shared/src/test/scala/fm/common/TestASCIIUtil.scala
@@ -44,6 +44,14 @@ final class TestASCIIUtil extends FunSuite with Matchers {
     ASCIIUtil.toASCIICharsOrNull('Æ') shouldBe "AE"
   }
 
+  test("toASCIICharsOrNull - accents - ignore whitelist") {
+    val whitelist: Set[Char] = Set('\u204E', 'Æ', '\u2052')
+
+    whitelist.foreach { c: Char =>
+      ASCIIUtil.toASCIICharsOrNull(c, whitelist) shouldBe null
+    }
+  }
+
   test("convertToASCII - ascii") {
     ASCIIUtil.convertToASCII(ascii) shouldBe theSameInstanceAs (ascii)
     ASCIIUtil.convertToASCII("foobar") shouldBe theSameInstanceAs ("foobar")


### PR DESCRIPTION
I'll open up a corresponding PR for `ta-catalog` where this will get used.  Having an ability to normalize a search query, but specify whitelisted characters (like `*`) will help unify the search query logic for solr & jooq field values.